### PR TITLE
fix(gui): 修复端到端质量评估 Image.open 收到 numpy.ndarray 的报错

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,18 +65,24 @@ src/semantic_transmission/
 - `docs/architecture.md` — 系统架构（模块关系、数据流、接口设计）
 - `docs/user-guide.md` — 使用指南
 - `docs/demo-handbook.md` — 演示手册（单机/双机操作步骤）
+- `docs/gui-design.md` — GUI 设计文档（Gradio 界面布局与交互设计）
 - `docs/cli-reference.md` — CLI 参考文档（semantic-tx 全部子命令参数说明）
 - `docs/project-overview.md` — 项目总览（面向负责人）
 - `resources/test_images/` — 测试用图片集
 
 ## CI 注意事项
 
+- **编辑代码前必须先创建 feature branch**（`git checkout -b <branch>`），禁止在 main 上直接修改
 - 推送前务必在本地运行 `uv run ruff check .` 和 `uv run ruff format --check .` 确认通过
 - CI 检查范围是整个项目（`.`），不仅限于 `src/`
 
 ## 文档规范
 
 - 文档中的流程图、拓扑图等使用 Mermaid 格式（```mermaid），不使用 ASCII art
+
+## GUI 开发注意事项
+
+- Gradio `gr.Image` 默认 `type="numpy"`，回调收到的是 `numpy.ndarray` 而非 PIL Image 或文件路径；需要文件路径时须显式指定 `type="filepath"`
 
 ## 环境前置条件
 

--- a/src/semantic_transmission/gui/pipeline_panel.py
+++ b/src/semantic_transmission/gui/pipeline_panel.py
@@ -351,6 +351,8 @@ def _run_evaluation(original_path, restored_img):
 
     if isinstance(restored_img, Image.Image):
         restored = restored_img.convert("RGB")
+    elif isinstance(restored_img, np.ndarray):
+        restored = Image.fromarray(restored_img).convert("RGB")
     else:
         restored = Image.open(restored_img).convert("RGB")
     restored_np = np.array(restored)


### PR DESCRIPTION
## Summary

- 修复 `pipeline_panel.py` 中 `_run_evaluation()` 对 Gradio 传入的 `numpy.ndarray` 类型未处理的问题，增加 `Image.fromarray()` 分支
- 更新 CLAUDE.md：补充 GUI 开发注意事项（Gradio `gr.Image` 默认类型坑）、CI 注意事项中前置 feature branch 提醒、关键资源补充 `gui-design.md`

Closes #2

## Test plan

- [x] 启动 GUI (`uv run semantic-tx gui`)，在端到端演示 Tab 运行完整流程，确认质量评估不再报错
- [x] CI lint/format 检查通过